### PR TITLE
Fixed wrong parameter name passed to construct_query

### DIFF
--- a/CardCollection/searchhandler.py
+++ b/CardCollection/searchhandler.py
@@ -23,4 +23,4 @@ class SearchHandler:
             list[Card]: A list of Card objects as search results.
         """
 
-        return Backend.construct_query(tupleList)
+        return Backend.construct_query(search_parameters)


### PR DESCRIPTION
The file was approved previously, then I found an error.

This line:

```python
        return Backend.construct_query(tupleList)
```

Should have been this:

```python
        return Backend.construct_query(search_parameters)
```

@CRam-irez make sure to pay attention to the actual parameter name being passed to the function you are ipmlementing. See the signature of the function:

```python
    def handle_search(self, search_parameters: list[tuple[str, str, str]]) -> list[Card]:
```
